### PR TITLE
Basic user authentication and creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'omniauth-facebook-access-token','0.1.6'
 gem 'koala'
 gem 'apns'
 gem 'librato-rails'
+gem 'bcrypt-ruby', require: 'bcrypt'
 
 gem 'draper', '1.3.1'
 gem 'verbs', '2.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,9 @@ GEM
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
+    bcrypt (3.1.9)
+    bcrypt-ruby (3.1.5)
+      bcrypt (>= 3.1.3)
     better_errors (2.0.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -349,6 +352,7 @@ PLATFORMS
 DEPENDENCIES
   annotate
   apns
+  bcrypt-ruby
   better_errors
   binding_of_caller
   capybara

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,13 +1,14 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :null_session
+  before_action :require_authentication
+  # protect_from_forgery with: :null_session
 
   private
 
-  def access_token
-    logger.debug request.headers['HTTP_ACCESS_TOKEN']
-    request.headers['HTTP_ACCESS_TOKEN']
+  def api_token
+    logger.debug request.headers['HTTP_API_TOKEN']
+    request.headers['HTTP_API_TOKEN']
   end
 
   def api_version
@@ -18,9 +19,9 @@ class ApplicationController < ActionController::Base
     if session[:user_id]
       logger.warn 'Getting user because the session had a user_id.'
       @current_user ||= User.find(session[:user_id]) if session[:user_id]
-    elsif access_token
+    elsif api_token
       logger.warn 'Getting user because request had an access token.'
-      @current_user ||= User.find_by_access_token access_token
+      @current_user ||= User.authenticate_by_api_token api_token
     end
 
   rescue ActiveRecord::RecordNotFound => e
@@ -38,5 +39,4 @@ class ApplicationController < ActionController::Base
   end
 
   helper_method :current_user
-  before_action :require_authentication
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,14 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def access_token
+    request.headers['HTTP_ACCESS_TOKEN']
+  end
+
+  def api_version
+    request.headers['HTTP_API_VERSION']
+  end
+
   def current_user
     # logger.debug request.headers.inspect
     logger.debug request.headers['HTTP_ACCESS_TOKEN']
@@ -12,7 +20,7 @@ class ApplicationController < ActionController::Base
     if session[:user_id]
       logger.warn 'Getting user because the session had a user_id.'
       @current_user ||= User.find(session[:user_id]) if session[:user_id]
-    elsif request.headers['HTTP_ACCESS_TOKEN']
+    elsif access_token
       logger.warn 'Getting user because request had an access token.'
       @urrent_user ||= User.find_by_access_token request.headers['HTTP_ACCESS_TOKEN']
     end
@@ -23,5 +31,16 @@ class ApplicationController < ActionController::Base
     redirect_to '/logout'
   end
 
+  def require_authentication
+    unless current_user
+      unauthorized
+    end
+  end
+
+  def unauthorized
+    render nothing: true, status: 401
+  end
+
   helper_method :current_user
+  before_filter :require_authentication
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   private
 
   def access_token
+    logger.debug request.headers['HTTP_ACCESS_TOKEN']
     request.headers['HTTP_ACCESS_TOKEN']
   end
 
@@ -14,15 +15,12 @@ class ApplicationController < ActionController::Base
   end
 
   def current_user
-    # logger.debug request.headers.inspect
-    logger.debug request.headers['HTTP_ACCESS_TOKEN']
-    # logger.debug request.headers['access_token']
     if session[:user_id]
       logger.warn 'Getting user because the session had a user_id.'
       @current_user ||= User.find(session[:user_id]) if session[:user_id]
     elsif access_token
       logger.warn 'Getting user because request had an access token.'
-      @urrent_user ||= User.find_by_access_token request.headers['HTTP_ACCESS_TOKEN']
+      @current_user ||= User.find_by_access_token access_token
     end
 
   rescue ActiveRecord::RecordNotFound => e
@@ -32,9 +30,7 @@ class ApplicationController < ActionController::Base
   end
 
   def require_authentication
-    unless current_user
-      unauthorized
-    end
+    unauthorized unless current_user
   end
 
   def unauthorized
@@ -42,5 +38,5 @@ class ApplicationController < ActionController::Base
   end
 
   helper_method :current_user
-  before_filter :require_authentication
+  before_action :require_authentication
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,18 +1,28 @@
 class SessionsController < ApplicationController
-  skip_before_action :require_authentication, only: [:create]
+  skip_before_action :require_authentication, only: [:create, :login]
 
+  # GET /auth/:provider/callback
   def create
     logger.debug env['omniauth.auth']
     user = User.from_omniauth env['omniauth.auth']
-    session[:user_id] = user.id
+    current_session user
     redirect_to root_url
   end
 
+  # POST /login
+  def login
+    user = User.authenticate login_params[:email], login_params[:password]
+    current_session user
+    redirect_to root_url
+  end
+
+  # GET /logout
   def destroy
-    session[:user_id] = nil
+    current_session nil
     redirect_to root_url
   end
 
+  # GET /user
   def show
     @user = current_user
   end
@@ -20,5 +30,20 @@ class SessionsController < ApplicationController
   def failure
     # TODO: Need to think about what should actually happen here.
     redirect_to root_url
+  end
+
+  private
+
+  def current_session(user)
+    if user
+      session[:user_id] = user.id
+    else
+      session[:user_id] = nil
+    end
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def login_params
+    params.permit(:email, :password)
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :require_authentication, only: [:create]
+
   def create
     logger.debug env['omniauth.auth']
     user = User.from_omniauth env['omniauth.auth']

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,27 @@
 class UsersController < ApplicationController
   before_action :set_user, only: []
+  skip_before_action :require_authentication, only: [:create]
+
+  # POST /users.json
+  def create
+    @user = User.new user_params
+
+    if @user.save
+      render :show, status: :created, location: @user
+    else
+      render json: @user.errors, status: :unprocessable_entity
+    end
+  end
 
   private
 
   # Use callbacks to share common setup or constraints between actions.
   def set_user
     @user = User.find(params[:id])
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def user_params
+    params.require(:user).permit(:email, :first_name, :last_name, :password)
   end
 end

--- a/app/views/sessions/show.json.jbuilder
+++ b/app/views/sessions/show.json.jbuilder
@@ -1,11 +1,2 @@
-if @user
-  json.(@user,
-    :id,
-    :first_name,
-    :last_name,
-    :birthday
-  )
-else
-  json.error 'Not authed. Goto /auth/facebook'
-  json.todo 'TODO: raise a proper 401 :-)'
-end
+@user.decorate
+json.extract! @user, :id, :email, :first_name, :last_name, :birthday

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -1,0 +1,2 @@
+user = @user.decorate
+json.extract! user, :id, :email, :first_name, :last_name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
 
   # You can have the root of your site routed with "root"
   root 'sessions#show', format: 'json'
+  get 'me', to: 'sessions#show', format: 'json'
 
   match 'auth/:provider/callback', to: 'sessions#create', via: [:get, :post]
   match 'auth/failure', to: redirect('/'), via: [:get, :post]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,12 +20,12 @@ Rails.application.routes.draw do
   # You can have the root of your site routed with "root"
   root 'sessions#show', format: 'json'
   get 'me', to: 'sessions#show', format: 'json'
+  get 'user' => 'sessions#show', format: 'json'
+  post 'users' => 'users#create', format: 'json'
 
   match 'auth/:provider/callback', to: 'sessions#create', via: [:get, :post]
   match 'auth/failure', to: redirect('/'), via: [:get, :post]
   match 'logout', to: 'sessions#destroy', as: 'logout', via: [:get, :post]
-
-  get 'user' => 'sessions#show', format: 'json'
 
   get 'messages', to: redirect('activities')
   get 'messages/sent' => 'messages#sent'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,13 +19,14 @@ Rails.application.routes.draw do
 
   # You can have the root of your site routed with "root"
   root 'sessions#show', format: 'json'
-  get 'me', to: 'sessions#show', format: 'json'
   get 'user' => 'sessions#show', format: 'json'
-  post 'users' => 'users#create', format: 'json'
-
+  post 'login' => 'sessions#login', format: 'json'
   match 'auth/:provider/callback', to: 'sessions#create', via: [:get, :post]
   match 'auth/failure', to: redirect('/'), via: [:get, :post]
   match 'logout', to: 'sessions#destroy', as: 'logout', via: [:get, :post]
+
+  # Registration route when not using an auth_provider
+  post 'users' => 'users#create', format: 'json'
 
   get 'messages', to: redirect('activities')
   get 'messages/sent' => 'messages#sent'

--- a/db/migrate/20150112014931_add_password_to_user.rb
+++ b/db/migrate/20150112014931_add_password_to_user.rb
@@ -1,6 +1,9 @@
 class AddPasswordToUser < ActiveRecord::Migration
   def change
     add_column :users, :password_digest, :string
+    add_column :users, :api_token, :string
+
     add_index :users, :email, unique: true
+    add_index :users, :api_token, unique: true
   end
 end

--- a/db/migrate/20150112014931_add_password_to_user.rb
+++ b/db/migrate/20150112014931_add_password_to_user.rb
@@ -1,6 +1,7 @@
 class AddPasswordToUser < ActiveRecord::Migration
   def change
-    add_column :users, :password, :string
+    add_column :users, :password_hash, :string
+    add_column :users, :password_salt, :string
     add_index :users, :email, unique: true
   end
 end

--- a/db/migrate/20150112014931_add_password_to_user.rb
+++ b/db/migrate/20150112014931_add_password_to_user.rb
@@ -1,0 +1,6 @@
+class AddPasswordToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :password, :string
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20150112014931_add_password_to_user.rb
+++ b/db/migrate/20150112014931_add_password_to_user.rb
@@ -1,7 +1,6 @@
 class AddPasswordToUser < ActiveRecord::Migration
   def change
-    add_column :users, :password_hash, :string
-    add_column :users, :password_salt, :string
+    add_column :users, :password_digest, :string
     add_index :users, :email, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,8 +77,7 @@ ActiveRecord::Schema.define(version: 20150112014931) do
     t.string   "birthday"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "password_hash"
-    t.string   "password_salt"
+    t.string   "password_digest"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,8 +78,10 @@ ActiveRecord::Schema.define(version: 20150112014931) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "password_digest"
+    t.string   "api_token"
   end
 
+  add_index "users", ["api_token"], name: "index_users_on_api_token", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141206021950) do
+ActiveRecord::Schema.define(version: 20150112014931) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,10 @@ ActiveRecord::Schema.define(version: 20141206021950) do
     t.string   "birthday"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "password_hash"
+    t.string   "password_salt"
   end
+
+  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
 
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ApplicationController, type: :controller do
 
   before :each do
     @user = FactoryGirl.create :user_with_facebook_auth
-    @valid_auth_token = @user.auth_providers.first.token
+    @valid_auth_token = @user.api_token
     @invalid_auth_toke = 'INVALIDAUTHTOKEN'
   end
 
@@ -27,13 +27,13 @@ RSpec.describe ApplicationController, type: :controller do
     end
 
     it 'returns correct user when valid header token is set' do
-      request.headers['HTTP_ACCESS_TOKEN'] = @valid_auth_token
+      request.headers['HTTP_API_TOKEN'] = @valid_auth_token
       get :index, {}
       expect(assigns(:current_user)).to eq(@user)
     end
 
     it 'returns nil when invalid header token is set' do
-      request.headers['HTTP_ACCESS_TOKEN'] = @invalid_auth_token
+      request.headers['HTTP_API_TOKEN'] = @invalid_auth_token
       get :index, {}
       expect(assigns(:current_user)).to eq(nil)
     end

--- a/spec/controllers/auth_providers_controller_spec.rb
+++ b/spec/controllers/auth_providers_controller_spec.rb
@@ -20,6 +20,10 @@ require 'rails_helper'
 
 RSpec.describe AuthProvidersController, type: :controller do
 
+  before :each do
+    @user = FactoryGirl.create :user
+  end
+
   # This should return the minimal set of attributes required to create a valid
   # AuthProvider. As you add validations to AuthProvider, be sure to
   # adjust the attributes here as well.
@@ -30,7 +34,7 @@ RSpec.describe AuthProvidersController, type: :controller do
   # This should return the minimal set of values that should be in the session
   # in order to pass any filters (e.g. authentication) defined in
   # AuthProvidersController. Be sure to keep this updated too.
-  let(:valid_session) { {} }
+  let(:valid_session) { { user_id: @user.id } }
 
   describe 'GET index' do
     it 'assigns all auth_providers as @auth_providers' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     birthday { Faker::Business.credit_card_expiry_date }
+    password 'password'
 
     factory :user_with_facebook_auth do
       after(:create) do |user|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -77,4 +77,25 @@ RSpec.describe User, type: :model do
       expect(@user.friends.first).to eq(@friend)
     end
   end
+
+  describe 'User authentication' do
+    before :each do
+      @user = FactoryGirl.create :user
+      @email = @user.email
+      @password = @user.password
+    end
+
+    it 'Should authenticate a user and return a model' do
+      user = User.authenticate @email, @password
+      expect(user).to eq(@user)
+    end
+
+    it 'Should hash the user\'s password' do
+      user = User.authenticate @email, @password
+      expect(user).to eq(@user)
+      expect(user.password).to be_nil
+      expect(user.password_hash).to be_truthy
+      expect(user.password_salt).to be_truthy
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -89,13 +89,5 @@ RSpec.describe User, type: :model do
       user = User.authenticate @email, @password
       expect(user).to eq(@user)
     end
-
-    it 'Should hash the user\'s password' do
-      user = User.authenticate @email, @password
-      expect(user).to eq(@user)
-      expect(user.password).to be_nil
-      expect(user.password_hash).to be_truthy
-      expect(user.password_salt).to be_truthy
-    end
   end
 end

--- a/spec/requests/auth_providers_spec.rb
+++ b/spec/requests/auth_providers_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe 'AuthProviders', type: :request do
   describe 'GET /auth_providers' do
     it 'works! (now write some real specs)' do
+      login_with_oauth
+
       get auth_providers_path
       expect(response.status).to be(200)
     end


### PR DESCRIPTION
- Require a proper session or access_token for all routes except those required to register or login.
- Allow users to be created by posting to /users.
- Hash and salt each user's password.
